### PR TITLE
Update responsive styles for Map Sidebar

### DIFF
--- a/client/components/Map/MainContainer/MapMainContainer.module.css
+++ b/client/components/Map/MainContainer/MapMainContainer.module.css
@@ -2,3 +2,7 @@
     width: 100%;
     height: 100%;
 }
+
+html:has(.Map) {
+    overflow: hidden;
+}

--- a/client/components/Map/Stops/Sidebar/Header/MapStopsSidebarHeader.module.css
+++ b/client/components/Map/Stops/Sidebar/Header/MapStopsSidebarHeader.module.css
@@ -6,6 +6,7 @@
     padding-right: 80px;
 
     background-color: #fff;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.12);
 }
 
 .MapStopsSidebarHeaderWrapper {
@@ -15,6 +16,7 @@
 
 .MapStopsSidebarHeaderInfo {
     display: flex;
+    align-items: center;
     gap: 10px;
     flex: 1;
 }

--- a/client/components/Map/Stops/Sidebar/Header/MapStopsSidebarHeader.tsx
+++ b/client/components/Map/Stops/Sidebar/Header/MapStopsSidebarHeader.tsx
@@ -31,7 +31,9 @@ export function MapStopsSidebarHeader({ types, name }: MapStopsSidebarHeaderProp
                             <IconFont key={t} name={IconFontCharsNames[t]} />
                         ))}
                     </Typography>
-                    <Typography variant="h3">{t(name)}</Typography>
+                    <Typography variant="h4">
+                        {t(name)}
+                    </Typography>
                 </div>
             </MapStopsSidebarRow>
             <Divider />

--- a/client/components/Map/Stops/Sidebar/Row/MapStopsSidebarRow.module.css
+++ b/client/components/Map/Stops/Sidebar/Row/MapStopsSidebarRow.module.css
@@ -1,3 +1,10 @@
 .MapStopsSidebarRow {
-    padding: 16px 24px;
+    padding: 20px 20px 8px;
+}
+
+@media screen and (min-width: 768px) {
+    .MapStopsSidebarRow {
+        padding-top: 16px;
+        padding-bottom: 12px;
+    }
 }

--- a/client/components/Map/Stops/Sidebar/StopsList/Item/MapStopsSidebarStopsListItem.module.css
+++ b/client/components/Map/Stops/Sidebar/StopsList/Item/MapStopsSidebarStopsListItem.module.css
@@ -3,27 +3,39 @@
     gap: 32px;
     cursor: pointer;
     border-radius: 4px;
-    box-shadow: 0 0 0 8px transparent;
+    transition: .15s ease;
+    box-shadow: 0 0 0 12px white;
+    background: white;
 }
 
-.MapStopsSidebarVehicle:not(.MapStopsSidebarVehicle_isSelected):hover {
-    background-color: #eaeaea;
-    box-shadow: 0 0 0 8px #eaeaea;
+@media (hover) {
+    .MapStopsSidebarVehicle:not(.MapStopsSidebarVehicle_isSelected):hover {
+        background: #f3f3f3;
+        box-shadow: 0 0 0 12px #f3f3f3;
+    }
+}
+
+.MapStopsSidebarVehicle:active {
+    filter: contrast(.9);
 }
 
 .MapStopsSidebarVehicle_isSelected {
-    background-color: var(--vehicle-color);
+    background: var(--vehicle-color);
     color: #fff;
-    box-shadow: 0 0 0 8px var(--vehicle-color);
+    box-shadow: 0 0 0 12px var(--vehicle-color);
 }
 
 .MapStopsSidebarVehicleInfo {
     display: flex;
+    align-items: center;
     gap: 16px;
     flex: 1;
 }
 
 .MapStopsSidebarVehicleRoute {
+    display: flex;
+    align-items: center;
+    justify-content: center;
     flex-shrink: 0;
 
     width: 58px;
@@ -31,9 +43,7 @@
     border-radius: 3px;
 
     font-weight: 500;
-    font-size: 28px;
-    line-height: 32px;
-    text-align: center;
+    font-size: 22px;
 
     color: #fff;
     background-color: var(--vehicle-color);
@@ -52,16 +62,33 @@
 }
 
 .MapStopsSidebarVehicleEndpoint {
-    font-size: 20px;
-    line-height: 22px;
+    padding-top: .2em;
+    font-size: 16px;
+    line-height: 1.1;
 }
 
 .MapStopsSidebarVehicleKeypoints,
 .MapStopsSidebarVehicleArriveTime {
-    font-size: 16px;
-    line-height: 18px;
+    padding-top: .5em;
+    font-size: 14px;
+    line-height: 1.125;
 }
 
 .MapStopsSidebarVehicleKeypoints {
     font-weight: 300;
+}
+
+@media screen and (min-width: 768px) {
+    .MapStopsSidebarVehicleRoute {
+        font-size: 28px;
+    }
+    
+    .MapStopsSidebarVehicleEndpoint {
+        font-size: 20px;
+    }
+
+    .MapStopsSidebarVehicleKeypoints,
+    .MapStopsSidebarVehicleArriveTime {
+        font-size: 16px;
+    }
 }

--- a/client/components/Map/Stops/Sidebar/StopsList/MapStopsSidebarStopsList.module.css
+++ b/client/components/Map/Stops/Sidebar/StopsList/MapStopsSidebarStopsList.module.css
@@ -1,10 +1,17 @@
 .MapStopsSidebarStopsList {
     display: flex;
     flex-direction: column;
-    gap: 30px;
-
+    gap: 26px;
+    padding-top: 18px;
     -ms-overflow-style: none;
     scrollbar-width: none;
+}
+
+@media screen and (min-width: 768px) {
+    .MapStopsSidebarStopsList {
+        gap: 30px;
+        padding-bottom: 18px;
+    }
 }
 
 .MapStopsSidebarStopsList::-webkit-scrollbar {

--- a/client/components/Map/Vehicles/Sidebar/MapVehiclesSidebar.module.css
+++ b/client/components/Map/Vehicles/Sidebar/MapVehiclesSidebar.module.css
@@ -59,7 +59,7 @@
 .MapVehiclesSidebarRoute {
     font-weight: 500;
     font-size: 32px;
-    line-height: 42px;
+    line-height: 1.125;
     text-align: center;
     width: 65px;
     border-radius: 4px;
@@ -144,7 +144,7 @@
     padding: 0;
     list-style: none;
     position: relative;
-    padding-left: 16px;
+    padding-left: 21px;
 }
 
 .MapVehiclesSidebarHeaderStation {
@@ -159,7 +159,7 @@
     content: '';
     width: 3px;
     position: absolute;
-    left: -14px;
+    left: -18px;
     background-color: #d2d9e8;
 }
 
@@ -181,13 +181,14 @@
     height: 11px;
     width: 11px;
     background-color: white;
-    left: -18px;
+    left: -22px;
     border: 3px solid #d2d9e8;
-    transform: translateY(-50%);
+    transform: translateY(-100%);
 }
 
 .MapVehiclesSidebarHeaderBullet_fill {
     background-color: #d2d9e8;
+    transform: translateY(-50%)
 }
 
 .MapVehiclesSidebarHeaderBullet_warning {
@@ -335,7 +336,7 @@
 }
 
 .MapVehiclesSidebarAdditionalWrapper {
-    padding: 40px 24px 50px;
+    padding: 40px 24px 0;
     display: flex;
     flex-direction: column;
     gap: 32px;

--- a/client/components/Map/Vehicles/Sidebar/MapVehiclesSidebar.module.css
+++ b/client/components/Map/Vehicles/Sidebar/MapVehiclesSidebar.module.css
@@ -7,6 +7,8 @@
     flex-direction: column;
 
     font-family: 'Iset Sans', sans-serif;
+    /* TODO: Remove area for Ecosystem logo */
+    padding-bottom: 80px;
 }
 
 .MapVehiclesSidebarCloseButton {

--- a/client/components/Map/Vehicles/Sidebar/MapVehiclesSidebar.tsx
+++ b/client/components/Map/Vehicles/Sidebar/MapVehiclesSidebar.tsx
@@ -298,7 +298,9 @@ export function MapVehiclesSidebar({
                     <ul className={cn(styles.MapVehiclesSidebarDirection)}>
                         <li className={cn(styles.MapVehiclesSidebarHeaderStation)}>
                             <div className={cn(styles.MapVehiclesSidebarHeaderBullet)} />
-                            <Typography variant="h3">{from}</Typography>
+                            <Typography variant="h4">
+                                {from}
+                            </Typography>
                         </li>
                         <li className={cn(styles.MapVehiclesSidebarHeaderStation)}>
                             <div
@@ -311,7 +313,7 @@ export function MapVehiclesSidebar({
                                 )}
                             />
                             <Typography
-                                variant="h3"
+                                variant="h4"
                                 className={cn({ [styles.MapVehiclesSidebarTo_warning]: warning })}
                             >
                                 {to}

--- a/client/components/UI/Modal/Modal.module.css
+++ b/client/components/UI/Modal/Modal.module.css
@@ -14,6 +14,8 @@
     display: none;
 }
 
+
+.ModalContent,
 .ModalContent > * {
     border-radius: 16px;
 }
@@ -48,7 +50,7 @@
     float: right;
     margin-bottom: -100%;
     top: 0;
-    padding: 16px;
+    padding: 12px;
     border: 0;
     background: none;
     cursor: pointer;
@@ -56,18 +58,45 @@
 }
 
 .ModalCloseButtonWrapper {
+    display: flex;
     justify-content: flex-end;
     z-index: 100;
 
-    background-color: rgba(255, 255, 255, 0.8);
+    background-color: rgba(255, 255, 255, 0.6);
     backdrop-filter: blur(8px);
+    color: rgba(0, 0, 0, 0.5);
     padding: 10px;
-    display: flex;
     border-radius: 50%;
+    transition: .15s ease;
+}
+
+.ModalCloseButtonWrapper svg {
+    width: 18px;
+    height: 18px;
+}
+
+@media screen and (min-width: 768px) {
+    .ModalCloseButtonWrapper svg {
+        width: 24px;
+        height: 24px;
+    }
+}
+
+@media (hover) {
+    .ModalCloseButton:hover .ModalCloseButtonWrapper {
+        background-color: rgba(255, 255, 255, 0.8);
+        color: rgba(0, 0, 0, 0.75);
+    }
+}
+
+.ModalCloseButton:active .ModalCloseButtonWrapper {
+    background-color: rgba(255, 255, 255, 0.95);
+    color: rgba(0, 0, 0, 1);
 }
 
 .ModalCloseIcon > path {
-    stroke: black;
+    stroke: currentColor;
+    transition: .15s ease;
 }
 
 @media screen and (max-width: 768px) {
@@ -75,10 +104,9 @@
         width: calc(100% - 16px);
         margin: 0;
         max-height: calc(100% - 90px);
-        left: 50% !important;
+        left: 8px !important;
         bottom: 0;
         top: initial !important;
-        transform: translate(-50%, 0);
         transition: height 150ms ease-out;
         will-change: height;
         border-bottom-left-radius: 0;

--- a/client/components/UI/Typography/Typography.module.css
+++ b/client/components/UI/Typography/Typography.module.css
@@ -17,26 +17,50 @@
 }
 
 .h1 {
-    font-size: 128px;
-    line-height: 128px;
+    font-size: 104px;
+    line-height: 1;
 }
 
 .h2 {
-    font-size: 48px;
-    line-height: 52px;
+    font-size: 39px;
+    line-height: 1.08;
 }
 
 .h3 {
     font-size: 32px;
-    line-height: 36px;
+    line-height: 1.11;
 }
 
 .h4 {
-    font-size: 22px;
-    line-height: 28px;
+    font-size: 26px;
+    line-height: 1.12;
 }
 
 .caption {
     font-size: 18px;
-    line-height: 24px;
+    line-height: 1.33;
+}
+
+@media screen and (min-width: 768px) {
+    .h1 {
+        font-size: 128px;
+        line-height: 1;
+    }
+    
+    .h2 {
+        font-size: 48px;
+        line-height: 1.08;
+    }
+
+    .h3 {
+        font-size: 40px;
+    }
+
+    .h4 {
+        font-size: 32px;
+    }
+
+    .caption {
+        font-size: 16px;
+    }
 }

--- a/client/public/icons/close.svg
+++ b/client/public/icons/close.svg
@@ -1,3 +1,3 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M3 3L21 21M3 21L21 3" stroke="black" stroke-width="3" stroke-linecap="square"/>
 </svg>


### PR DESCRIPTION
Updated responsive styles for Sidebar:
- [x] Typography
- [x] Spacers
- [x] Close icon in Header
- [x] :hover/:active styles

### Additionally
- [x] Add spacer before Ecosystem Logo
- [x] Prevent map scroll (html tag)