### PR TITLE
Fix check-types (remove node-fetch & form-data polyfills)

### DIFF
--- a/common/package.json
+++ b/common/package.json
@@ -7,13 +7,10 @@
   },
   "dependencies": {
     "encoding": "^0.1.13",
-    "form-data": "^4.0.0",
-    "node-fetch": "^2.7.0",
     "tslib": "^2.6.2",
     "typescript": "^4.9.5"
   },
   "devDependencies": {
-    "@types/node": "^18.17.15",
-    "@types/node-fetch": "^2.6.4"
+    "@types/node": "^20.14.3"
   }
 }

--- a/common/strapi/create-methods.ts
+++ b/common/strapi/create-methods.ts
@@ -1,5 +1,3 @@
-import fetch, { Response } from 'node-fetch';
-
 import { StrapiContentTypes } from '../types/strapi';
 import { parallelRequests } from '../utils/parallelRequests';
 import { STRAPI_URL, REQUEST_PAGINATION_SIZE } from './constants';
@@ -123,7 +121,7 @@ export function createStrapiMethods(contentType: StrapiContentTypes, jwt?: strin
                     throw new Error(rawResult.statusText);
                 }
 
-                const result = await rawResult.json();
+                const result = await rawResult.json() as any;
 
                 if (result.error) {
                     throw new Error(JSON.stringify(result.error));

--- a/common/strapi/login.ts
+++ b/common/strapi/login.ts
@@ -1,5 +1,3 @@
-import fetch from 'node-fetch';
-
 import { StrapiLoginResponse } from '../types/strapi';
 import { STRAPI_URL, EMAIL, PASSWORD } from './constants';
 

--- a/common/strapi/upload.ts
+++ b/common/strapi/upload.ts
@@ -1,6 +1,3 @@
-import fetch from 'node-fetch';
-import FormData from 'form-data';
-
 import { STRAPI_URL } from './constants';
 
 export async function deleteFile(id: number, jwt: string) {
@@ -20,7 +17,6 @@ export async function uploadFile(data: FormData, jwt: string) {
     try {
         const resp = await fetch(`${STRAPI_URL}/api/upload`, {
             headers: {
-                ...data.getHeaders(),
                 ...(jwt ? { Authorization: `Bearer ${jwt}` } : {}),
             },
             method: 'POST',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,12 +142,6 @@ importers:
       encoding:
         specifier: ^0.1.13
         version: 0.1.13
-      form-data:
-        specifier: ^4.0.0
-        version: 4.0.0
-      node-fetch:
-        specifier: ^2.7.0
-        version: 2.7.0(encoding@0.1.13)
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -156,26 +150,17 @@ importers:
         version: 4.9.5
     devDependencies:
       '@types/node':
-        specifier: ^18.17.15
-        version: 18.17.15
-      '@types/node-fetch':
-        specifier: ^2.6.4
-        version: 2.6.4
+        specifier: ^20.14.3
+        version: 20.14.3
 
   schedulers:
     dependencies:
-      form-data:
-        specifier: ^4.0.0
-        version: 4.0.0
       jsdom:
         specifier: ^23.0.1
         version: 23.0.1
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
-      node-fetch:
-        specifier: ^3.3.2
-        version: 3.3.2
       transport-common:
         specifier: workspace:*
         version: link:../common
@@ -190,14 +175,11 @@ importers:
         specifier: ^4.14.202
         version: 4.14.202
       '@types/node':
-        specifier: ^20.10.3
-        version: 20.10.3
-      '@types/node-fetch':
-        specifier: 2.6.9
-        version: 2.6.9
+        specifier: ^20.14.3
+        version: 20.14.3
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.1(@types/node@20.10.3)(typescript@5.3.2)
+        version: 10.9.1(@types/node@20.14.3)(typescript@5.3.2)
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -213,15 +195,12 @@ importers:
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
-      node-fetch:
-        specifier: ^3.3.2
-        version: 3.3.2
       transport-common:
         specifier: workspace:*
         version: link:../common
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.1(@types/node@20.10.3)(typescript@5.3.2)
+        version: 10.9.1(@types/node@20.14.3)(typescript@5.3.2)
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -239,11 +218,8 @@ importers:
         specifier: ^4.14.202
         version: 4.14.202
       '@types/node':
-        specifier: ^20.10.3
-        version: 20.10.3
-      '@types/node-fetch':
-        specifier: ^2.6.9
-        version: 2.6.9
+        specifier: ^20.14.3
+        version: 20.14.3
       nodemon:
         specifier: ^3.0.2
         version: 3.0.2
@@ -2183,13 +2159,13 @@ packages:
     resolution: {integrity: sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==}
     dependencies:
       '@types/connect': 3.4.35
-      '@types/node': 20.10.5
+      '@types/node': 20.14.3
     dev: true
 
   /@types/connect@3.4.35:
     resolution: {integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==}
     dependencies:
-      '@types/node': 20.10.5
+      '@types/node': 20.14.3
     dev: true
 
   /@types/estree@1.0.0:
@@ -2199,7 +2175,7 @@ packages:
   /@types/express-serve-static-core@4.17.33:
     resolution: {integrity: sha512-TPBqmR/HRYI3eC2E5hmiivIzv+bidAfXofM+sbonAGvyDhySGw9/PQZFt2BLOrjUUR++4eJVpx6KnLQK1Fk9tA==}
     dependencies:
-      '@types/node': 20.10.5
+      '@types/node': 20.14.3
       '@types/qs': 6.9.7
       '@types/range-parser': 1.2.4
     dev: true
@@ -2224,7 +2200,7 @@ packages:
   /@types/jsdom@21.1.6:
     resolution: {integrity: sha512-/7kkMsC+/kMs7gAYmmBR9P0vGTnOoLhQhyhQJSlXGI5bzTHp6xdo0TtKWQAsz6pmSAeVqKSbqeyP6hytqr9FDw==}
     dependencies:
-      '@types/node': 20.10.5
+      '@types/node': 20.14.3
       '@types/tough-cookie': 4.0.2
       parse5: 7.1.2
     dev: true
@@ -2251,31 +2227,13 @@ packages:
     resolution: {integrity: sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==}
     dev: true
 
-  /@types/node-fetch@2.6.4:
-    resolution: {integrity: sha512-1ZX9fcN4Rvkvgv4E6PAY5WXUFWFcRWxZa3EW83UjycOB9ljJCedb2CupIP4RZMEwF/M3eTcCihbBRgwtGbg5Rg==}
-    dependencies:
-      '@types/node': 20.10.5
-      form-data: 3.0.1
-    dev: true
-
-  /@types/node-fetch@2.6.9:
-    resolution: {integrity: sha512-bQVlnMLFJ2d35DkPNjEPmd9ueO/rh5EiaZt2bhqiSarPjZIuIV6bPQVqcrEyvNo+AfTrRGVazle1tl597w3gfA==}
-    dependencies:
-      '@types/node': 20.10.5
-      form-data: 4.0.0
-    dev: true
-
-  /@types/node@18.17.15:
-    resolution: {integrity: sha512-2yrWpBk32tvV/JAd3HNHWuZn/VDN1P+72hWirHnvsvTGSqbANi+kSeuQR9yAHnbvaBvHDsoTdXV0Fe+iRtHLKA==}
-    dev: true
-
-  /@types/node@20.10.3:
-    resolution: {integrity: sha512-XJavIpZqiXID5Yxnxv3RUDKTN5b81ddNC3ecsA0SoFXz/QU8OGBwZGMomiq0zw+uuqbL/krztv/DINAQ/EV4gg==}
+  /@types/node@20.10.5:
+    resolution: {integrity: sha512-nNPsNE65wjMxEKI93yOP+NPGGBJz/PoN3kZsVLee0XMiJolxSekEVD8wRwBUBqkwc7UWop0edW50yrCQW4CyRw==}
     dependencies:
       undici-types: 5.26.5
 
-  /@types/node@20.10.5:
-    resolution: {integrity: sha512-nNPsNE65wjMxEKI93yOP+NPGGBJz/PoN3kZsVLee0XMiJolxSekEVD8wRwBUBqkwc7UWop0edW50yrCQW4CyRw==}
+  /@types/node@20.14.3:
+    resolution: {integrity: sha512-Nuzqa6WAxeGnve6SXqiPAM9rA++VQs+iLZ1DDd56y0gdvygSZlQvZuvdFPR3yLqkVxPu4WrO02iDEyH1g+wazw==}
     dependencies:
       undici-types: 5.26.5
 
@@ -2319,7 +2277,7 @@ packages:
     resolution: {integrity: sha512-NUo5XNiAdULrJENtJXZZ3fHtfMolzZwczzBbnAeBbqBwG+LaG6YaJtuwzwGSQZ2wsCrxjEhNNjAkKigy3n8teQ==}
     dependencies:
       '@types/mime': 3.0.1
-      '@types/node': 20.10.5
+      '@types/node': 20.14.3
     dev: true
 
   /@types/tough-cookie@4.0.2:
@@ -2504,7 +2462,7 @@ packages:
     resolution: {integrity: sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==}
     engines: {node: '>= 14'}
     dependencies:
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -2695,6 +2653,7 @@ packages:
 
   /asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+    dev: false
 
   /autoprefixer@10.4.16(postcss@8.4.32):
     resolution: {integrity: sha512-7vd3UC6xKp0HLfua5IjZlcXvGAGy7cBAXTg2lyQ/8WpNhd6SiZ8Be+xm3FyBSYJx5GKcpRCzBh7RH4/0dnY+uQ==}
@@ -2971,6 +2930,7 @@ packages:
     engines: {node: '>= 0.8'}
     dependencies:
       delayed-stream: 1.0.0
+    dev: false
 
   /commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
@@ -3104,11 +3064,6 @@ packages:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
     dev: true
 
-  /data-uri-to-buffer@4.0.1:
-    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
-    engines: {node: '>= 12'}
-    dev: false
-
   /data-urls@5.0.0:
     resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
     engines: {node: '>=18'}
@@ -3138,6 +3093,18 @@ packages:
     dependencies:
       ms: 2.1.3
     dev: true
+
+  /debug@4.3.4:
+    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
+    dev: false
 
   /debug@4.3.4(supports-color@5.5.0):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
@@ -3216,6 +3183,7 @@ packages:
   /delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
+    dev: false
 
   /depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -4024,14 +3992,6 @@ packages:
       reusify: 1.0.4
     dev: true
 
-  /fetch-blob@3.2.0:
-    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
-    engines: {node: ^12.20 || >= 14.13}
-    dependencies:
-      node-domexception: 1.0.0
-      web-streams-polyfill: 3.2.1
-    dev: false
-
   /figma-squircle@0.3.1:
     resolution: {integrity: sha512-cyb7fbNaJgM3XrMXRq/B4NPUILfbrSRHjqt+0/3OGBOejJKNLnFKTXSMSAjdqbw2bSo2Y2eCnYXvaRgshBnWQw==}
     dev: false
@@ -4098,15 +4058,6 @@ packages:
       is-callable: 1.2.7
     dev: true
 
-  /form-data@3.0.1:
-    resolution: {integrity: sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==}
-    engines: {node: '>= 6'}
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      mime-types: 2.1.35
-    dev: true
-
   /form-data@4.0.0:
     resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
     engines: {node: '>= 6'}
@@ -4114,12 +4065,6 @@ packages:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       mime-types: 2.1.35
-
-  /formdata-polyfill@4.0.10:
-    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
-    engines: {node: '>=12.20.0'}
-    dependencies:
-      fetch-blob: 3.2.0
     dev: false
 
   /forwarded@0.2.0:
@@ -4377,7 +4322,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.0
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -4387,7 +4332,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.0
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -5005,12 +4950,14 @@ packages:
   /mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
+    dev: false
 
   /mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
     dependencies:
       mime-db: 1.52.0
+    dev: false
 
   /mime@1.6.0:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
@@ -5109,33 +5056,6 @@ packages:
     dependencies:
       lower-case: 2.0.2
       tslib: 2.6.2
-
-  /node-domexception@1.0.0:
-    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
-    engines: {node: '>=10.5.0'}
-    dev: false
-
-  /node-fetch@2.7.0(encoding@0.1.13):
-    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
-    engines: {node: 4.x || >=6.0.0}
-    peerDependencies:
-      encoding: ^0.1.0
-    peerDependenciesMeta:
-      encoding:
-        optional: true
-    dependencies:
-      encoding: 0.1.13
-      whatwg-url: 5.0.0
-    dev: false
-
-  /node-fetch@3.3.2:
-    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    dependencies:
-      data-uri-to-buffer: 4.0.1
-      fetch-blob: 3.2.0
-      formdata-polyfill: 4.0.10
-    dev: false
 
   /node-releases@2.0.10:
     resolution: {integrity: sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==}
@@ -6242,10 +6162,6 @@ packages:
       url-parse: 1.5.10
     dev: false
 
-  /tr46@0.0.3:
-    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
-    dev: false
-
   /tr46@5.0.0:
     resolution: {integrity: sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==}
     engines: {node: '>=18'}
@@ -6262,7 +6178,7 @@ packages:
       typescript: 5.3.3
     dev: true
 
-  /ts-node@10.9.1(@types/node@20.10.3)(typescript@5.3.2):
+  /ts-node@10.9.1(@types/node@20.14.3)(typescript@5.3.2):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -6281,7 +6197,7 @@ packages:
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
-      '@types/node': 20.10.3
+      '@types/node': 20.14.3
       acorn: 8.8.2
       acorn-walk: 8.2.0
       arg: 4.1.3
@@ -6588,15 +6504,6 @@ packages:
       xml-name-validator: 5.0.0
     dev: false
 
-  /web-streams-polyfill@3.2.1:
-    resolution: {integrity: sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==}
-    engines: {node: '>= 8'}
-    dev: false
-
-  /webidl-conversions@3.0.1:
-    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-    dev: false
-
   /webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
@@ -6620,13 +6527,6 @@ packages:
     dependencies:
       tr46: 5.0.0
       webidl-conversions: 7.0.0
-    dev: false
-
-  /whatwg-url@5.0.0:
-    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
-    dependencies:
-      tr46: 0.0.3
-      webidl-conversions: 3.0.1
     dev: false
 
   /which-boxed-primitive@1.0.2:

--- a/schedulers/package.json
+++ b/schedulers/package.json
@@ -7,18 +7,15 @@
     "update:transphoto": "ts-node transphoto/index.ts"
   },
   "dependencies": {
-    "form-data": "^4.0.0",
     "jsdom": "^23.0.1",
     "lodash": "^4.17.21",
-    "node-fetch": "^3.3.2",
     "transport-common": "workspace:*",
     "transport-server": "workspace:*"
   },
   "devDependencies": {
     "@types/jsdom": "^21.1.6",
     "@types/lodash": "^4.14.202",
-    "@types/node": "^20.10.3",
-    "@types/node-fetch": "2.6.9",
+    "@types/node": "^20.14.3",
     "ts-node": "^10.9.1",
     "tslib": "^2.6.2",
     "typescript": "^5.3.2"

--- a/schedulers/transphoto/crawler.ts
+++ b/schedulers/transphoto/crawler.ts
@@ -1,6 +1,5 @@
 import { JSDOM } from 'jsdom';
 import { isUndefined } from 'lodash';
-import fetch from 'node-fetch';
 
 import { ClientUnit, UnitInfo } from 'transport-common/types/masstrans';
 

--- a/schedulers/transphoto/index.ts
+++ b/schedulers/transphoto/index.ts
@@ -1,7 +1,4 @@
 import _ from 'lodash';
-import fetch from 'node-fetch';
-
-import FormData from 'form-data';
 
 import { createStrapiMethods } from 'transport-common/strapi/create-methods';
 import { deleteFile, uploadFile } from 'transport-common/strapi/upload';
@@ -49,7 +46,7 @@ async function updateUnitInfoInStrapi(
             let imageId: number | undefined = undefined;
 
             if (info.imageUrl) {
-                const imageFile = await fetch(info.imageUrl).then((res) => res.buffer());
+                const imageFile = await fetch(info.imageUrl).then((res : any) => res.buffer());
                 const form = new FormData();
 
                 form.append('files', imageFile, `${info.type}-${info.boardNumber}.jpg`);
@@ -78,7 +75,7 @@ async function updateUnitInfoInStrapi(
             }
 
             if (info.imageUrl && info.imageUrl !== infoFromStrapi.imageUrl) {
-                const imageFile = await fetch(info.imageUrl).then((res) => res.buffer());
+                const imageFile = await fetch(info.imageUrl).then((res : any) => res.buffer());
                 const form = new FormData();
 
                 form.append('files', imageFile, `${info.type}-${info.boardNumber}.jpg`);

--- a/server/package.json
+++ b/server/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "express": "^4.18.2",
     "lodash": "^4.17.21",
-    "node-fetch": "^3.3.2",
     "transport-common": "workspace:*",
     "ts-node": "^10.9.1",
     "tslib": "^2.6.2",
@@ -21,8 +20,7 @@
     "@types/express": "^4.17.21",
     "@types/js-sha1": "^0.6.2",
     "@types/lodash": "^4.14.202",
-    "@types/node": "^20.10.3",
-    "@types/node-fetch": "^2.6.9",
+    "@types/node": "^20.14.3",
     "nodemon": "^3.0.2"
   }
 }


### PR DESCRIPTION
I fix `pnpm run check-types`. Removed 2 packages conflicted with native `fetch` & `FormData` APIs from`@types/node` >= 18:
  - `node-fetch`
  - `form-data`

And update `@types/node` to 20.x